### PR TITLE
glass_table.cc: fix compilation if logs are enabled

### DIFF
--- a/xapian-core/backends/glass/glass_table.cc
+++ b/xapian-core/backends/glass/glass_table.cc
@@ -1723,7 +1723,7 @@ GlassTable::GlassTable(const char * tablename_, const string & path_,
 	  last_readahead(BLK_UNUSED),
 	  offset(0)
 {
-    LOGCALL_CTOR(DB, "GlassTable", tablename_ | path_ | readonly_ | compress_strategy | lazy_);
+    LOGCALL_CTOR(DB, "GlassTable", tablename_ | path_ | readonly_ | lazy_);
 }
 
 GlassTable::GlassTable(const char * tablename_, int fd, off_t offset_,
@@ -1758,7 +1758,7 @@ GlassTable::GlassTable(const char * tablename_, int fd, off_t offset_,
 	  last_readahead(BLK_UNUSED),
 	  offset(offset_)
 {
-    LOGCALL_CTOR(DB, "GlassTable", tablename_ | fd | offset_ | readonly_ | compress_strategy | lazy_);
+    LOGCALL_CTOR(DB, "GlassTable", tablename_ | fd | offset_ | readonly_ | lazy_);
 }
 
 bool


### PR DESCRIPTION
The unused parameter compress_strategy parameter breaks compilation if configure is run with --enable-logs.  This might also go upstream.
